### PR TITLE
Fix the version information returned from RtlGetVersion.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -3756,3 +3756,33 @@ const (
 	DRIVE_CDROM       = 5
 	DRIVE_RAMDISK     = 6
 )
+
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw
+const (
+	VER_PLATFORM_WIN32_NT = 2
+)
+
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw
+const (
+	VER_NT_SERVER            = 0x0000003
+	VER_NT_DOMAIN_CONTROLLER = 0x0000002
+	VER_NT_WORKSTATION       = 0x0000001
+)
+
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw
+const (
+	VER_SUITE_BACKOFFICE               = 0x00000004
+	VER_SUITE_BLADE                    = 0x00000400
+	VER_SUITE_COMPUTE_SERVER           = 0x00004000
+	VER_SUITE_DATACENTER               = 0x00000080
+	VER_SUITE_ENTERPRISE               = 0x00000002
+	VER_SUITE_EMBEDDEDNT               = 0x00000040
+	VER_SUITE_PERSONAL                 = 0x00000200
+	VER_SUITE_SINGLEUSERTS             = 0x00000100
+	VER_SUITE_SMALLBUSINESS            = 0x00000001
+	VER_SUITE_SMALLBUSINESS_RESTRICTED = 0x00000020
+	VER_SUITE_STORAGE_SERVER           = 0x00002000
+	VER_SUITE_TERMINAL                 = 0x00000010
+	VER_SUITE_WH_SERVER                = 0x00008000
+	VER_SUITE_MULTIUSERTS              = 0x00020000
+)

--- a/functions.go
+++ b/functions.go
@@ -27,6 +27,7 @@ var (
 	msimg32  = syscall.NewLazyDLL("msimg32.dll")
 	mpr      = syscall.NewLazyDLL("mpr.dll")
 	ntoskrnl = syscall.NewLazyDLL("ntoskrnl.exe")
+	ntdll    = syscall.NewLazyDLL("ntdll.dll")
 
 	registerClassEx                  = user32.NewProc("RegisterClassExW")
 	unregisterClass                  = user32.NewProc("UnregisterClassW")
@@ -445,7 +446,7 @@ var (
 	wNetAddConnection3    = mpr.NewProc("WNetAddConnection3W")
 	wNetCancelConnection2 = mpr.NewProc("WNetCancelConnection2W")
 
-	rtlGetVersion = ntoskrnl.NewProc("RtlGetVersion")
+	rtlGetVersion = ntdll.NewProc("RtlGetVersion")
 )
 
 // RegisterClassEx sets the Size of the WNDCLASSEX automatically.
@@ -4379,6 +4380,7 @@ func WNetCancelConnection2(name string, flags uint32, force bool) uint32 {
 	return uint32(ret)
 }
 
+// https://docs.microsoft.com/en-us/windows/win32/devnotes/rtlgetversion
 func RtlGetVersion() RTL_OSVERSIONINFOEXW {
 	var info RTL_OSVERSIONINFOEXW
 	info.OSVersionInfoSize = 5*4 + 128*2 + 3*2 + 2*1

--- a/types.go
+++ b/types.go
@@ -1264,6 +1264,7 @@ type POWERBROADCAST_SETTING struct {
 	Data         [1]byte
 }
 
+// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw
 type RTL_OSVERSIONINFOEXW struct {
 	OSVersionInfoSize uint32
 	MajorVersion      uint32


### PR DESCRIPTION
The version information returned from ntoskrnl.exe doesn't apparently include
the extended version information. The version in ntdll.dll does. Also added a
number of constants that make interpreting the version data easier.